### PR TITLE
LED interference workaround

### DIFF
--- a/firmware/Platypus.cpp
+++ b/firmware/Platypus.cpp
@@ -98,8 +98,8 @@ void platypusLoop_()
 void platypus::init()
 {
   Scheduler.startLoop(platypusLoop_);
-  pixels.begin();
-  pixels.show();
+  //pixels.begin();
+  //pixels.show();
 }
 
 Led::Led()
@@ -116,11 +116,11 @@ void Led::set(int red, int green, int blue)
   r_ = red;
   g_ = green;
   b_ = blue;
-
+  /*
   while (!pixels.canShow());
   for (size_t pixel_idx = 0; pixel_idx < board::NUM_LEDS; ++pixel_idx)
     pixels.setPixelColor(pixel_idx, r_, g_, b_);
-  pixels.show();
+  pixels.show();*/
 }
 
 void Led::R(int red)

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -356,7 +356,7 @@ void motorUpdateLoop()
   // Set the LED for current system state.
   unsigned c = (millis() >> 3) & 0xFF;
   if (c > 128) c = 255 - c;
-
+ 
   switch (system_state)
   {
   case DISCONNECTED:


### PR DESCRIPTION
Disabling all calls to NeoPixel object in platypus.cpp which cause the arming signal for the motors to fail (no output on signal pin). Not sure if we want this in the 4.2.0 branch for now while we work on a fix?